### PR TITLE
App is unusable when using windows dark theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import {View, Button, StyleSheet} from 'react-native';
+import {AppTheme} from 'react-native-windows';
 import {
+  DefaultTheme,
+  DarkTheme,
   NavigationContainer,
   useNavigationState,
 } from '@react-navigation/native';
@@ -82,7 +85,8 @@ function renderScreen(i) {
 
 export default function App() {
   return (
-    <NavigationContainer>
+    <NavigationContainer
+      theme={AppTheme.currentTheme === 'dark' ? DarkTheme : DefaultTheme}>
       <MyDrawer />
     </NavigationContainer>
   );

--- a/windows/rngallery.sln
+++ b/windows/rngallery.sln
@@ -54,7 +54,6 @@ Global
 		..\node_modules\react-native-windows\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{da8b35b3-da00-4b02-bde6-6a397b3fd46b}*SharedItemsImports = 9
 		..\node_modules\react-native-windows\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{eaf81beb-a159-4421-9b6d-e59c37828a57}*SharedItemsImports = 4
 		..\node_modules\react-native-windows\Chakra\Chakra.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
-		..\node_modules\react-native-windows\JSI\Shared\JSI.Shared.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 		..\node_modules\react-native-windows\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 		..\node_modules\react-native-windows\Mso\Mso.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 		..\node_modules\react-native-windows\Shared\Shared.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4


### PR DESCRIPTION
react-navigation adds components to the tree that have hard coded colors.  This ended up with the app having a very light gray background behind the pages.  When windows is in dark theme the text of the pages, and the checkbox control follow the windows theme and would be almost invisible.